### PR TITLE
Use URL-encoded WebUI login and secure cookie jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ DL_THRESHOLD_KBPS=33           # Reconnect if < 33 KB/s download
 # qBittorrent WebUI
 WEBUI_URL="http://192.168.1.50:8080"
 WEBUI_USER="admin"
-WEBUI_PASS="your_password"
+WEBUI_PASS="your_password"        # supports special characters
 
 # Port forwarding
 PF_RENEW_SECS=45               # NAT-PMP renewal interval
@@ -144,6 +144,8 @@ DNS_HEALTH=true                # Enable DNS latency checks
 DNS_LAT_MS=250                 # DNS latency threshold
 QBIT_HEALTH=true               # Enable qBittorrent health checks
 ```
+
+`WEBUI_PASS` accepts passwords with special characters.
 
 ## Usage
 

--- a/pvpnwg.sh
+++ b/pvpnwg.sh
@@ -354,7 +354,16 @@ wg_unhealthy_reason(){
 # ===========================
 # qBittorrent helpers
 # ===========================
-qb_login(){ :>"$COOKIE_JAR"; local r; r=$(curl -sS -c "$COOKIE_JAR" -d "username=${WEBUI_USER}&password=${WEBUI_PASS}" "${WEBUI_URL%/}/api/v2/auth/login" || true); [[ "$r" == Ok.* ]]; }
+qb_login(){
+  :>"$COOKIE_JAR"
+  chmod 600 "$COOKIE_JAR"
+  local r
+  r=$(curl -sS -c "$COOKIE_JAR" \
+      --data-urlencode "username=${WEBUI_USER}" \
+      --data-urlencode "password=${WEBUI_PASS}" \
+      "${WEBUI_URL%/}/api/v2/auth/login" || true)
+  [[ "$r" == Ok.* ]]
+}
 qb_set_port_webui(){
   local port="$1"
   qb_login || { log "WARN: qBittorrent WebUI login failed"; return 1; }

--- a/tests/integration/test_netns.bats
+++ b/tests/integration/test_netns.bats
@@ -269,7 +269,11 @@ teardown_mock_qb_webui() {
     
     function qb_login() {
         : > "$COOKIE_JAR"
-        local r; r=$(curl -sS -c "$COOKIE_JAR" -d "username=${WEBUI_USER}&password=${WEBUI_PASS}" "${WEBUI_URL%/}/api/v2/auth/login" || true)
+        chmod 600 "$COOKIE_JAR"
+        local r; r=$(curl -sS -c "$COOKIE_JAR" \
+            --data-urlencode "username=${WEBUI_USER}" \
+            --data-urlencode "password=${WEBUI_PASS}" \
+            "${WEBUI_URL%/}/api/v2/auth/login" || true)
         [[ "$r" == Ok.* ]]
     }
     


### PR DESCRIPTION
## Summary
- URL-encode WebUI credentials when logging in and restrict the qBittorrent cookie jar to user-only access.
- Document that WebUI passwords may contain special characters.
- Mirror the login changes in integration tests.

## Testing
- `BATS_LIB_PATH=tests bats tests/unit/test_pvpnwg.bats tests/integration/test_netns.bats` *(fails: conf_validate, usage, network namespace setup, and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68be9781cab08329820fee6277f536ff