### PR TITLE
Refactor killswitch and CLI wrappers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,10 +13,10 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-log() { echo -e "${GREEN}[INFO]${NC} $*"; }
-warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-error() { echo -e "${RED}[ERROR]${NC} $*"; }
-die() { error "$*"; exit 1; }
+log() { echo -e "${GREEN}[INFO]${NC}" "$@"; }
+warn() { echo -e "${YELLOW}[WARN]${NC}" "$@"; }
+error() { echo -e "${RED}[ERROR]${NC}" "$@"; }
+die() { error "$@"; exit 1; }
 
 check_root() {
     [[ ${EUID} -eq 0 ]] || die "Run as root (sudo)"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -12,10 +12,10 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-log() { echo -e "${GREEN}[INFO]${NC} $*"; }
-warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-error() { echo -e "${RED}[ERROR]${NC} $*"; }
-die() { error "$*"; exit 1; }
+log() { echo -e "${GREEN}[INFO]${NC}" "$@"; }
+warn() { echo -e "${YELLOW}[WARN]${NC}" "$@"; }
+error() { echo -e "${RED}[ERROR]${NC}" "$@"; }
+die() { error "$@"; exit 1; }
 
 check_root() {
     [[ ${EUID} -eq 0 ]] || die "Run as root (sudo)"


### PR DESCRIPTION
## Summary
- add proper function terminators and guard main for sourcing
- adjust tests to load helpers directly and skip unsupported env checks
- expand interface name in nft killswitch rules
- preserve log arguments and DNS backup paths by quoting `"$@"`

## Testing
- `bash -n pvpnwg.sh install.sh uninstall.sh`
- `shfmt -w -i 2 -ci -bn pvpnwg.sh`
- `shfmt -i 2 -ci -bn install.sh uninstall.sh`
- `shellcheck pvpnwg.sh install.sh uninstall.sh` *(warnings: unused vars, eval risks)*
- `bats tests/unit` *(fails: conf_validate accepts valid config; select_conf skips invalid configs)*
- `bats tests/integration` *(all tests skipped: network namespaces unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68beafba0fc8832983ee121d1f4b25f4