### PR TITLE
Harden qBittorrent handling and health checks

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,6 +22,7 @@ check_root() {
 }
 
 stop_and_disable_services() {
+    command -v systemctl >/dev/null 2>&1 || { warn "systemd not available"; return; }
     log "Stopping and disabling systemd services..."
     
     local services=(
@@ -46,6 +47,7 @@ stop_and_disable_services() {
 }
 
 remove_systemd_units() {
+    command -v systemctl >/dev/null 2>&1 || { warn "systemd not available"; return; }
     log "Removing systemd units..."
     
     local units=(


### PR DESCRIPTION
## Summary
- Replace `eval` in run helper with safe command execution
- Normalize WireGuard health checks and add qBittorrent login hardening
- Restore `nullglob` after temporary use and guard uninstaller against missing systemd

## Testing
- `shellcheck pvpnwg.sh uninstall.sh install.sh`
- `bats tests/unit/test_pvpnwg.bats` *(fails: conf_validate accepts valid config, select_conf skips invalid configs)*
- `bats tests/integration/test_netns.bats` *(all tests skipped: network namespaces unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68beb6ead3c483299a165cde47bfd79d