### PR TITLE
Improve sudo vs user path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ sudo pvpnwg diag all
 ### Environment Overrides
 ```bash
 # Custom home directory
-PVPN_PHOME="/custom/path" sudo pvpnwg status
+PHOME="/custom/path" sudo pvpnwg status
 
 # JSON logging
 LOG_JSON=true sudo pvpnwg connect
@@ -494,7 +494,7 @@ VERBOSE=1 sudo pvpnwg pf start
 # Development environment
 cp ~/.pvpnwg/pvpnwg.conf ~/.pvpnwg/pvpnwg-dev.conf
 # Edit dev config, then:
-PVPN_PHOME="/home/user/.pvpnwg-dev" sudo pvpnwg init
+PHOME="/home/user/.pvpnwg-dev" sudo pvpnwg init
 ```
 
 ### Custom Systemd Units
@@ -509,7 +509,7 @@ sudo systemctl edit pvpn-check.timer
 sudo systemctl edit pvpn-pf.service
 # Add:
 # [Service]
-# Environment="PVPN_PHOME=/custom/path"
+# Environment="PHOME=/custom/path"
 ```
 
 ## Security Considerations

--- a/install.sh
+++ b/install.sh
@@ -184,33 +184,19 @@ EOF
 setup_user_config() {
     local user="${SUDO_USER:-$(logname 2>/dev/null || echo root)}"
     local home_dir
-    
-    if [[ "$user" == "root" ]]; then
-        home_dir="/root"
-    else
-        home_dir="/home/$user"
-    fi
-    
+    home_dir="$(getent passwd "$user" | cut -d: -f6)"
     local phome="${home_dir}/.pvpnwg"
-    
+
     log "Setting up user configuration for: $user"
     log "PHOME will be: $phome"
-    
-    if [[ ! -d "$phome" ]]; then
-        sudo -u "$user" mkdir -p "$phome/configs" "$phome/state" "$phome/tmp"
-        sudo -u "$user" chmod 700 "$phome"
-        log "✓ Created $phome"
-    else
-        log "✓ $phome already exists"
-    fi
-    
+
     if [[ ! -f "$phome/pvpnwg.conf" ]]; then
         log "Running init to create default config..."
-        PVPN_PHOME="$phome" "${INSTALL_DIR}/${BIN_NAME}" init
+        sudo -u "$user" "${INSTALL_DIR}/${BIN_NAME}" init
     else
         log "✓ Config already exists at $phome/pvpnwg.conf"
     fi
-    
+
     echo
     echo "Next steps:"
     echo "1. Copy your Proton WireGuard .conf files to: $phome/configs/"

--- a/tests/unit/test_pvpnwg.bats
+++ b/tests/unit/test_pvpnwg.bats
@@ -13,9 +13,15 @@ setup() {
     export TMP_DIR="$PHOME/tmp"
     export VERBOSE=0
     export DRY_RUN=1
-    
-    mkdir -p "$PHOME" "$CONFIG_DIR" "$STATE_DIR" "$TMP_DIR"
-    
+
+    mkdir -p "$PHOME" "$CONFIG_DIR" "$STATE_DIR" "$TMP_DIR" "$TEST_TMPDIR/bin"
+    PATH="$TEST_TMPDIR/bin:$PATH"
+    cat >"$TEST_TMPDIR/bin/wg-quick" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+    chmod +x "$TEST_TMPDIR/bin/wg-quick"
+
     # Source the script functions (skip main execution)
     source ./pvpnwg.sh 2>/dev/null || true
 }

--- a/tests/unit/test_user_paths.bats
+++ b/tests/unit/test_user_paths.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# tests/unit/test_user_paths.bats — verify user detection and ownership
+
+SCRIPT="$BATS_TEST_DIRNAME/../../pvpnwg.sh"
+
+@test "SUDO_USER determines run user and ownership" {
+    user="pvuser1"
+    userdel -r "$user" 2>/dev/null || true
+    useradd -m "$user"
+    run env -i PATH="$PATH" SUDO_USER="$user" HOME="/root" bash "$SCRIPT" init
+    [ "$status" -eq 0 ]
+    conf="/home/$user/.pvpnwg/pvpnwg.conf"
+    log="/home/$user/.pvpnwg/pvpn.log"
+    [ -f "$conf" ]
+    [ "$(stat -c '%U' "$conf")" = "$user" ]
+    [ "$(stat -c '%U' "$log")" = "$user" ]
+    userdel -r "$user"
+}
+
+@test "--user overrides SUDO_USER" {
+    usera="pvuser2a"
+    userb="pvuser2b"
+    userdel -r "$usera" 2>/dev/null || true
+    userdel -r "$userb" 2>/dev/null || true
+    useradd -m "$usera"
+    useradd -m "$userb"
+    run env -i PATH="$PATH" SUDO_USER="$usera" HOME="/root" bash "$SCRIPT" --user "$userb" init
+    [ "$status" -eq 0 ]
+    [ -d "/home/$userb/.pvpnwg" ]
+    [ ! -e "/home/$usera/.pvpnwg/pvpnwg.conf" ]
+    [ "$(stat -c '%U' "/home/$userb/.pvpnwg/pvpnwg.conf")" = "$userb" ]
+    userdel -r "$usera"
+    userdel -r "$userb"
+}
+
+@test "init run as non-root creates user-owned files" {
+    user="pvuser3"
+    userdel -r "$user" 2>/dev/null || true
+    useradd -m "$user"
+    run sudo -u "$user" bash "$SCRIPT" init
+    [ "$status" -eq 0 ]
+    conf="/home/$user/.pvpnwg/pvpnwg.conf"
+    [ -f "$conf" ]
+    [ "$(stat -c '%U' "$conf")" = "$user" ]
+    userdel -r "$user"
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -109,13 +109,9 @@ cleanup_vpn_state() {
 handle_user_data() {
     local user="${SUDO_USER:-$(logname 2>/dev/null || echo root)}"
     local home_dir
-    
-    if [[ "$user" == "root" ]]; then
-        home_dir="/root"
-    else
-        home_dir="/home/$user"
-    fi
-    
+    home_dir="$(getent passwd "$user" | cut -d: -f6)"
+    home_dir="${home_dir:-/root}"
+
     local phome="${home_dir}/.pvpnwg"
     
     if [[ -d "$phome" ]]; then
@@ -145,13 +141,9 @@ handle_user_data() {
 restore_dns_if_needed() {
     local user="${SUDO_USER:-$(logname 2>/dev/null || echo root)}"
     local home_dir
-    
-    if [[ "$user" == "root" ]]; then
-        home_dir="/root"
-    else
-        home_dir="/home/$user"
-    fi
-    
+    home_dir="$(getent passwd "$user" | cut -d: -f6)"
+    home_dir="${home_dir:-/root}"
+
     local dns_backup="${home_dir}/.pvpnwg/state/dns_backup.tar"
     
     if [[ -f "$dns_backup" ]]; then


### PR DESCRIPTION
## Summary
- derive per-user configuration paths from invoking account and drop PVPN_PHOME
- create runtime directories and logs with correct ownership using install
- ensure qBittorrent cookie jar and init-generated config are owned by the target user
- add unit tests covering SUDO_USER and `--user` overrides and non-root init

## Testing
- `bats tests/unit/test_pvpnwg.bats`
- `bats tests/unit/test_user_paths.bats`
- `bats tests/integration/test_netns.bats`


------
https://chatgpt.com/codex/tasks/task_e_68bed043cf408329ac9ca42edb802076