### PR TITLE
Add sudo alternative handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,7 +75,35 @@ check_deps() {
 
 check_sudo_config() {
     log "Ensure passwordless sudo is configured for pvpnwg runtime commands"
-    command -v sudo >/dev/null 2>&1 || warn "sudo not installed"
+
+    if command -v sudo >/dev/null 2>&1; then
+        return
+    fi
+
+    if [[ ${EUID} -ne 0 ]]; then
+        die "sudo is required but not installed"
+    fi
+
+    if [[ "$RUN_USER" != "root" ]]; then
+        command -v su >/dev/null 2>&1 \
+            || die "sudo not installed and 'su' unavailable to switch to ${RUN_USER}"
+        log "sudo not installed; will fall back to 'su'"
+    fi
+}
+
+run_as_user() {
+    local target="$1"
+    shift
+
+    if command -v sudo >/dev/null 2>&1; then
+        sudo -n -u "$target" "$@"
+    elif [[ "$(id -un)" == "$target" ]]; then
+        "$@"
+    elif command -v su >/dev/null 2>&1; then
+        su - "$target" -c "$(printf '%q ' "$@")"
+    else
+        die "Unable to run commands as $target: missing sudo and su"
+    fi
 }
 
 install_binary() {
@@ -197,7 +225,7 @@ setup_user_config() {
 
     if [[ ! -f "$phome/pvpnwg.conf" ]]; then
         log "Running init to create default config..."
-        sudo -u "$user" "${INSTALL_DIR}/${BIN_NAME}" init
+        run_as_user "$user" "${INSTALL_DIR}/${BIN_NAME}" init
     else
         log "✓ Config already exists at $phome/pvpnwg.conf"
     fi

--- a/install.sh
+++ b/install.sh
@@ -5,10 +5,20 @@ set -euo pipefail
 # Pre-parse for --user override
 CLI_USER=""
 ARGS=()
-for arg in "$@"; do
-    case "$arg" in
-        --user=*) CLI_USER="${arg#*=}" ;;
-        *) ARGS+=("$arg") ;;
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --user=*)
+            CLI_USER="${1#*=}"
+            shift
+            ;;
+        --user)
+            CLI_USER="$2"
+            shift 2
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
     esac
 done
 set -- "${ARGS[@]}"
@@ -20,6 +30,10 @@ elif [[ -n "${SUDO_USER:-}" ]]; then
     RUN_USER="$SUDO_USER"
 else
     RUN_USER="$(id -un)"
+fi
+if ! getent passwd "$RUN_USER" >/dev/null 2>&1; then
+    echo "Unknown user: $RUN_USER" >&2
+    exit 1
 fi
 RUN_HOME="$(getent passwd "$RUN_USER" | cut -d: -f6)"
 

--- a/pvpnwg.sh
+++ b/pvpnwg.sh
@@ -135,7 +135,10 @@ run_as_user() {
   elif command -v sudo >/dev/null 2>&1; then
     sudo -n -u "#$RUN_UID" "$@"
   elif command -v su >/dev/null 2>&1; then
-    su - "#$RUN_UID" -c "$(printf '%q ' "$@")"
+    local target
+    target="$(getent passwd "$RUN_UID" | cut -d: -f1 || true)"
+    target="${target:-$RUN_UID}"
+    su -s /bin/sh "$target" -c "$(printf '%q ' "$@")"
   else
     die "Unable to run command as UID $RUN_UID: missing sudo and su"
   fi

--- a/pvpnwg.sh
+++ b/pvpnwg.sh
@@ -116,8 +116,12 @@ if [[ -n "${PF_PROTO_LIST:-}" ]]; then IFS=', ' read -r -a PF_PROTO_LIST <<<"${P
 run_as_user() {
   if [[ $EUID -eq "$RUN_UID" ]]; then
     "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo -n -u "#$RUN_UID" "$@"
+  elif command -v su >/dev/null 2>&1; then
+    su - "#$RUN_UID" -c "$(printf '%q ' "$@")"
   else
-    sudo -u "#$RUN_UID" "$@"
+    die "Unable to run command as UID $RUN_UID: missing sudo and su"
   fi
 }
 

--- a/tests/mock/bin/sudo
+++ b/tests/mock/bin/sudo
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# mock sudo for test environment: runs commands without password prompts
+set -euo pipefail
+
+# ignore non-interactive flag
+if [[ "${1:-}" == "-n" ]]; then
+    shift
+fi
+
+target=""
+if [[ "${1:-}" == "-u" ]]; then
+    target="$2"
+    shift 2
+fi
+
+if [[ -n "$target" ]]; then
+    if [[ "$target" == \#* ]]; then
+        uid="${target#\#}"
+        target="$(getent passwd "$uid" | cut -d: -f1)"
+    fi
+    if [[ "$(id -un)" == "$target" ]]; then
+        exec "$@"
+    else
+        exec su "$target" -c "$(printf '%q ' "$@")"
+    fi
+else
+    exec "$@"
+fi
+

--- a/tests/unit/test_pvpnwg.bats
+++ b/tests/unit/test_pvpnwg.bats
@@ -17,7 +17,7 @@ setup() {
     export DRY_RUN=1
     export PVPNWG_USER="$(id -un)"
 
-    mkdir -p "$PHOME" "$CONFIG_DIR" "$STATE_DIR" "$TMPDIR"
+    mkdir -p "$PHOME" "$CONFIG_DIR" "$STATE_DIR" "$TMP_DIR"
     
     # Source the script functions (skip main execution)
     source ./pvpnwg.sh 2>/dev/null || true

--- a/tests/unit/test_user_paths.bats
+++ b/tests/unit/test_user_paths.bats
@@ -3,6 +3,10 @@
 
 SCRIPT="$BATS_TEST_DIRNAME/../../pvpnwg.sh"
 
+setup() {
+    export PATH="$BATS_TEST_DIRNAME/../mock/bin:$PATH"
+}
+
 run_as() {
     local user="$1"
     shift


### PR DESCRIPTION
## Summary
- fail install if neither sudo nor su can switch user
- run pvpnwg commands via sudo, su, or direct exec
- allow tests to run without sudo

## Testing
- `bats tests/unit/test_user_paths.bats` *(fails: --user overrides SUDO_USER; init run as non-root creates user-owned files; --user rejects unknown user)*
- `env -i PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" SUDO_USER="fallbacktest" HOME="/root" bash install.sh` *(fails: sudo not installed and 'su' unavailable to switch to fallbacktest)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb7e4f3a88329aac1c2031eedf564