### PR TITLE
Fix temporary directory variable in tests

### DIFF
--- a/tests/unit/test_pvpnwg.bats
+++ b/tests/unit/test_pvpnwg.bats
@@ -17,7 +17,7 @@ setup() {
     export DRY_RUN=1
     export PVPNWG_USER="$(id -un)"
 
-    mkdir -p "$PHOME" "$CONFIG_DIR" "$STATE_DIR" "$TMPDIR"
+    mkdir -p "$PHOME" "$CONFIG_DIR" "$STATE_DIR" "$TMP_DIR"
     
     # Source the script functions (skip main execution)
     source ./pvpnwg.sh 2>/dev/null || true


### PR DESCRIPTION
## Summary
- fix test setup to use TMP_DIR variable when creating directories

## Testing
- `bats tests/unit/test_pvpnwg.bats`

------
https://chatgpt.com/codex/tasks/task_e_68bfbc8e66808329a082ae5211a0f887