### PR TITLE
harden DNS restore tar extraction

### DIFF
--- a/pvpnwg.sh
+++ b/pvpnwg.sh
@@ -58,6 +58,7 @@ WEBUI_USER_DEFAULT="admin"
 WEBUI_PASS_DEFAULT="change_me"
 QB_CONF_PATH_DEFAULT="${RUN_HOME}/.config/qBittorrent/qBittorrent.conf"
 
+# shellcheck disable=SC2034
 PF_GATEWAY_FALLBACK_DEFAULT="10.2.0.1"
 PF_RENEW_SECS_DEFAULT=45
 PF_STATIC_FALLBACK_PORT_DEFAULT=51820
@@ -242,10 +243,37 @@ dns_backup() {
   detect_dns_backend
   case "$dns_backend" in systemd-resolved | flat) _dns_tar /etc/resolv.conf ;; resolvconf) _dns_tar /etc/resolvconf /etc/resolv.conf ;; esac
 }
+dns_restore_generic() {
+  detect_dns_backend
+  case "$dns_backend" in
+    systemd-resolved)
+      _run resolvectl revert "$IFACE" || true ;;
+    resolvconf)
+      _run resolvconf -u || true ;;
+    *)
+      : >"$TMP_DIR/resolv.conf.generic"
+      printf '%s\n' "nameserver 1.1.1.1" "nameserver 8.8.8.8" >>"$TMP_DIR/resolv.conf.generic"
+      _run cp -f "$TMP_DIR/resolv.conf.generic" /etc/resolv.conf || true ;;
+  esac
+  log "DNS restored generically"
+}
 dns_restore() {
   if [[ -f "$DNS_BACKUP" ]]; then
-    _run tar -xpf "$DNS_BACKUP" -C /
-    log "DNS restored from backup"
+    if tar -tf "$DNS_BACKUP" | grep -E '(^/|(^|/)\.\.(/|$))' >/dev/null; then
+      log "Unsafe paths in DNS backup; using generic restore"
+      dns_restore_generic
+      return
+    fi
+    local tmp
+    tmp=$(mktemp -d)
+    if _run tar -xpf "$DNS_BACKUP" -C "$tmp"; then
+      _run cp -a "$tmp/." /
+      log "DNS restored from backup"
+    else
+      log "DNS backup extraction failed; using generic restore"
+      dns_restore_generic
+    fi
+    rm -rf "$tmp"
   else
     vlog "No DNS backup"
   fi


### PR DESCRIPTION
## Summary
- verify DNS backup archives before extraction and reject unsafe paths
- extract DNS backups in a temp directory before copying
- fall back to a generic DNS restore when backups are unsafe or extraction fails
- keep `PF_GATEWAY_FALLBACK_DEFAULT` and use 1.1.1.1/8.8.8.8 in generic DNS restore

## Testing
- `shellcheck pvpnwg.sh uninstall.sh`
- `bats tests/unit` *(fails: mkdir: cannot create directory ''; 38 tests, 34 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb7d98bc88329856e64561a04390e