### PR TITLE
Use URL-encoded credentials for qB login

### DIFF
--- a/pvpnwg.sh
+++ b/pvpnwg.sh
@@ -711,9 +711,10 @@ qb_login() {
   else
     install -m 600 /dev/null "$COOKIE_JAR"
   fi
-  if ! printf 'username=%s&password=%s' "$WEBUI_USER" "$WEBUI_PASS" |
-    curl -sS --fail --connect-timeout 10 -c "$COOKIE_JAR" \
-      --data-binary @- "${WEBUI_URL%/}/api/v2/auth/login" >/dev/null; then
+  if ! curl -sS --fail --connect-timeout 10 -c "$COOKIE_JAR" \
+      --data-urlencode "username=${WEBUI_USER}" \
+      --data-urlencode "password=${WEBUI_PASS}" \
+      "${WEBUI_URL%/}/api/v2/auth/login" >/dev/null; then
     log "WARN: qBittorrent WebUI login failed"
     return 1
   fi


### PR DESCRIPTION
## Summary
- send qBittorrent credentials using curl `--data-urlencode` instead of a raw printf pipe
- add regression test ensuring `qb_login` handles special characters in usernames and passwords

## Testing
- `bats tests/unit/test_pvpnwg.bats`


------
https://chatgpt.com/codex/tasks/task_e_68bfcdd424048329bf44e89b482188d6