### PR TITLE
Use dedicated iptables chain for killswitch rules

### DIFF
--- a/pvpnwg.sh
+++ b/pvpnwg.sh
@@ -1232,12 +1232,15 @@ killswitch_iptables_enable() {
     log "iptables not installed"
     return 1
   fi
-_run iptables -I OUTPUT 1 -m state --state ESTABLISHED,RELATED -j ACCEPT
-_run iptables -I OUTPUT 2 -o "$IFACE" -j ACCEPT
-_run iptables -A OUTPUT -d 127.0.0.0/8 -j ACCEPT
-_run iptables -A OUTPUT -d 10.0.0.0/8 -j ACCEPT
-_run iptables -A OUTPUT -d 172.16.0.0/12 -j ACCEPT
-_run iptables -A OUTPUT -d 192.168.0.0/16 -j ACCEPT
+  _run iptables -N pvpnwg-out >/dev/null 2>&1 || true
+  _run iptables -F pvpnwg-out
+  _run iptables -I OUTPUT 1 -j pvpnwg-out
+  _run iptables -A pvpnwg-out -m state --state ESTABLISHED,RELATED -j ACCEPT
+  _run iptables -A pvpnwg-out -o "$IFACE" -j ACCEPT
+  _run iptables -A pvpnwg-out -d 127.0.0.0/8 -j ACCEPT
+  _run iptables -A pvpnwg-out -d 10.0.0.0/8 -j ACCEPT
+  _run iptables -A pvpnwg-out -d 172.16.0.0/12 -j ACCEPT
+  _run iptables -A pvpnwg-out -d 192.168.0.0/16 -j ACCEPT
   local host port ip4
   if ip link show "$IFACE" >/dev/null 2>&1 && wg show "$IFACE" endpoints | grep -q ':'; then
     host=$(wg show "$IFACE" endpoints | awk '{print $2}' | awk -F: '{print $1; exit}')
@@ -1248,9 +1251,9 @@ _run iptables -A OUTPUT -d 192.168.0.0/16 -j ACCEPT
   fi
   if [[ -n $host && -n $port ]]; then
     ip4=$(getent ahostsv4 "$host" | awk '/STREAM/ {print $1; exit}')
-    [[ -n $ip4 ]] && _run iptables -I OUTPUT 3 -o "$LAN_IF" -p udp -d "$ip4" --dport "$port" -j ACCEPT
+    [[ -n $ip4 ]] && _run iptables -A pvpnwg-out -o "$LAN_IF" -p udp -d "$ip4" --dport "$port" -j ACCEPT
   fi
-_run iptables -P OUTPUT DROP
+  _run iptables -P OUTPUT DROP
   log "Killswitch (iptables) enabled"
 }
 
@@ -1259,8 +1262,9 @@ killswitch_iptables_disable() {
     log "iptables not installed"
     return 1
   }
-_run iptables -P OUTPUT ACCEPT
-_run iptables -F OUTPUT
+  _run iptables -P OUTPUT ACCEPT
+  _run iptables -D OUTPUT -j pvpnwg-out >/dev/null 2>&1 || true
+  _run iptables -F pvpnwg-out >/dev/null 2>&1 || true
   log "Killswitch (iptables) disabled"
 }
 

--- a/tests/mock/bin/iptables
+++ b/tests/mock/bin/iptables
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# mock iptables for tests
+exit 1

--- a/tests/unit/test_killswitch.bats
+++ b/tests/unit/test_killswitch.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+# tests/unit/test_killswitch.bats — tests for iptables killswitch
+
+load ../test_helper.bats
+
+setup() {
+    setup_test_env
+    PATH="$PWD/tests/mock/bin:$PATH"
+    export PATH
+    export PVPNWG_USER="$(id -un)"
+    source ./pvpnwg.sh 2>/dev/null || true
+    export DRY_RUN=1
+}
+
+teardown() {
+    cleanup_test_env
+}
+
+@test "killswitch_iptables_enable uses custom chain" {
+    run killswitch_iptables_enable
+    [ "$status" -eq 0 ]
+    grep -q "iptables -N pvpnwg-out" "$LOG_FILE"
+    grep -q "iptables -I OUTPUT 1 -j pvpnwg-out" "$LOG_FILE"
+    grep -q "iptables -A pvpnwg-out -m state --state ESTABLISHED,RELATED -j ACCEPT" "$LOG_FILE"
+}
+
+@test "killswitch_iptables_disable flushes custom chain" {
+    run killswitch_iptables_disable
+    [ "$status" -eq 0 ]
+    grep -q "iptables -P OUTPUT ACCEPT" "$LOG_FILE"
+    grep -q "iptables -D OUTPUT -j pvpnwg-out" "$LOG_FILE"
+    grep -q "iptables -F pvpnwg-out" "$LOG_FILE"
+    ! grep -q "iptables -F OUTPUT" "$LOG_FILE"
+}


### PR DESCRIPTION
## Summary
- Add custom `pvpnwg-out` chain and direct OUTPUT traffic to it
- Install iptables rules in `pvpnwg-out` and flush only that chain when disabling
- Add unit tests and mock iptables helper

## Testing
- `bats tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_68bfcd65bbc483298601c9bba58093ef