### PR TITLE
Fix IPv6 AllowedIPs stripping test

### DIFF
--- a/tests/unit/test_pvpnwg.bats
+++ b/tests/unit/test_pvpnwg.bats
@@ -236,7 +236,12 @@ EOF
 [Peer]
 AllowedIPs = 0.0.0.0/0, ::/0
 EOF
+    # Run command with real side effects and without sudo stub
+    DRY_RUN=0
+    SUDO_READY=1
+    SUDO_CMD=""
     conf_strip_ipv6_allowedips
+    DRY_RUN=1
     run grep -c '::/0' "$TARGET_CONF"
     [ "$status" -eq 1 ]
 }


### PR DESCRIPTION
## Summary
- Ensure `conf_strip_ipv6_allowedips` unit test runs the real sed command without sudo

## Testing
- `tests/run-tests.sh unit/test_pvpnwg.bats`

------
https://chatgpt.com/codex/tasks/task_e_68c12d8455288329b93f771a60a33863